### PR TITLE
Update - Code structuration

### DIFF
--- a/lib/Pages/Files.dart
+++ b/lib/Pages/Files.dart
@@ -1,106 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:navbar_custom/Pages/Homepage.dart';
-import 'package:navbar_custom/Pages/Info.dart'; // Assuming this is your Informations page
-import 'package:navbar_custom/Pages/Settings.dart';
 
-class Files extends StatelessWidget {
-  const Files({super.key});
+class FilesPage extends StatelessWidget {
+  const FilesPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 5,
-        backgroundColor: Colors.blueAccent,
-        centerTitle: true,
-        title: Text(
-          "Files",
-          style: GoogleFonts.poppins(
-            fontSize: 15,
-            color: Colors.white,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-      ),
-      body: Center(
-        child: Text(
-          "My files",
-          style: GoogleFonts.poppins(
-            fontSize: 20,
-            color: Colors.black,
-            fontWeight: FontWeight.w400,
-          ),
-        ),
-      ),
-      bottomNavigationBar: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.5),
-              blurRadius: 25,
-              offset: const Offset(0, 20),
-            )
-          ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(25),
-          child: NavigationBar(
-            indicatorColor: Colors.blueAccent,
-            elevation: 0,
-            height: 70,
-            selectedIndex: 1, // 'Files' is at index 1
-            onDestinationSelected: (indexPage) {
-              // Function to navigate without transition
-              void navigateWithoutTransition(Widget page) {
-                Navigator.push(
-                  context,
-                  PageRouteBuilder(
-                    pageBuilder: (context, animation1, animation2) => page,
-                    transitionDuration: Duration.zero, // No transition duration
-                    transitionsBuilder:
-                        (context, animation1, animation2, child) {
-                      return child; // Return the child directly, no animation
-                    },
-                  ),
-                );
-              }
-
-              switch (indexPage) {
-                case 0:
-                  navigateWithoutTransition(const Homepage());
-                  break;
-                case 1:
-                // This Page - no navigation needed as we are already here
-                  break;
-                case 2:
-                  navigateWithoutTransition(const Informations());
-                  break;
-                case 3:
-                  navigateWithoutTransition(Settings());
-                  break;
-              }
-            },
-            destinations: const [
-              NavigationDestination(
-                icon: Icon(Icons.home_filled),
-                label: "Homepage",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.book_sharp),
-                label: "Files",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.info_sharp),
-                label: "Informations",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.settings),
-                label: "Settings",
-              ),
-            ],
-          ),
+    return Center(
+      child: Text(
+        "My Files",
+        style: GoogleFonts.poppins(
+          fontSize: 20,
+          color: Colors.black,
+          fontWeight: FontWeight.w400,
         ),
       ),
     );

--- a/lib/Pages/Homepage.dart
+++ b/lib/Pages/Homepage.dart
@@ -1,106 +1,19 @@
+// lib/pages/home_page.dart
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:navbar_custom/Pages/Files.dart';
-import 'package:navbar_custom/Pages/Info.dart'; // Assuming this is your Informations page
-import 'package:navbar_custom/Pages/Settings.dart';
 
-class Homepage extends StatelessWidget {
-  const Homepage({super.key});
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 5,
-        backgroundColor: Colors.blueAccent,
-        centerTitle: true,
-        title: Text(
-          "Homepage",
-          style: GoogleFonts.poppins(
-            fontSize: 15,
-            color: Colors.white,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-      ),
-      body: Center(
-        child: Text(
-          "Your Homepage",
-          style: GoogleFonts.poppins(
-            fontSize: 20,
-            color: Colors.black,
-            fontWeight: FontWeight.w400,
-          ),
-        ),
-      ),
-      bottomNavigationBar: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.5),
-              blurRadius: 25,
-              offset: const Offset(0, 20),
-            )
-          ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(25),
-          child: NavigationBar(
-            indicatorColor: Colors.blueAccent,
-            elevation: 0,
-            height: 70,
-            selectedIndex: 0, // 'Homepage' is at index 0
-            onDestinationSelected: (indexPage) {
-              // Helper function to navigate without transition
-              void navigateWithoutTransition(Widget page) {
-                Navigator.push(
-                  context,
-                  PageRouteBuilder(
-                    pageBuilder: (context, animation1, animation2) => page,
-                    transitionDuration: Duration.zero, // No transition duration
-                    transitionsBuilder:
-                        (context, animation1, animation2, child) {
-                      return child; // Return the child directly, no animation
-                    },
-                  ),
-                );
-              }
-
-              switch (indexPage) {
-                case 0:
-                // This page - no navigation needed as we are already here
-                  break;
-                case 1:
-                  navigateWithoutTransition(const Files());
-                  break;
-                case 2:
-                  navigateWithoutTransition(const Informations());
-                  break;
-                case 3:
-                  navigateWithoutTransition(Settings());
-                  break;
-              }
-            },
-            destinations: const [
-              NavigationDestination(
-                icon: Icon(Icons.home_filled),
-                label: "Homepage",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.book_sharp),
-                label: "Files",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.info_sharp),
-                label: "Informations",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.settings),
-                label: "Settings",
-              ),
-            ],
-          ),
+    return Center(
+      child: Text(
+        "Welcome to Homepage!",
+        style: GoogleFonts.poppins(
+          fontSize: 20,
+          color: Colors.black,
+          fontWeight: FontWeight.w400,
         ),
       ),
     );

--- a/lib/Pages/Info.dart
+++ b/lib/Pages/Info.dart
@@ -1,106 +1,19 @@
+// lib/pages/informations_page.dart
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:navbar_custom/Pages/Files.dart';
-import 'package:navbar_custom/Pages/Homepage.dart';
-import 'package:navbar_custom/Pages/Settings.dart';
 
-class Informations extends StatelessWidget {
-  const Informations({super.key});
+class InformationsPage extends StatelessWidget {
+  const InformationsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 5,
-        backgroundColor: Colors.blueAccent,
-        centerTitle: true,
-        title: Text(
-          "Informations",
-          style: GoogleFonts.poppins(
-            fontSize: 15,
-            color: Colors.white,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-      ),
-      body: Center(
-        child: Text(
-          "Your Informations",
-          style: GoogleFonts.poppins(
-            fontSize: 20,
-            color: Colors.black,
-            fontWeight: FontWeight.w400,
-          ),
-        ),
-      ),
-      bottomNavigationBar: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.5),
-              blurRadius: 25,
-              offset: const Offset(0, 20),
-            )
-          ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(25),
-          child: NavigationBar(
-            indicatorColor: Colors.blueAccent,
-            elevation: 0,
-            height: 70,
-            selectedIndex: 2, // 'Informations' is at index 2
-            onDestinationSelected: (indexPage) {
-              // Helper function to navigate without transition
-              void navigateWithoutTransition(Widget page) {
-                Navigator.push(
-                  context,
-                  PageRouteBuilder(
-                    pageBuilder: (context, animation1, animation2) => page,
-                    transitionDuration: Duration.zero, // No transition duration
-                    transitionsBuilder:
-                        (context, animation1, animation2, child) {
-                      return child; // Return the child directly, no animation
-                    },
-                  ),
-                );
-              }
-
-              switch (indexPage) {
-                case 0:
-                  navigateWithoutTransition(const Homepage());
-                  break;
-                case 1:
-                  navigateWithoutTransition(const Files());
-                  break;
-                case 2:
-                // This page - no navigation needed as we are already here
-                  break;
-                case 3:
-                  navigateWithoutTransition(Settings());
-                  break;
-              }
-            },
-            destinations: const [
-              NavigationDestination(
-                icon: Icon(Icons.home_filled),
-                label: "Homepage",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.book_sharp),
-                label: "Files",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.info_sharp),
-                label: "Informations",
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.settings),
-                label: "Settings",
-              ),
-            ],
-          ),
+    return Center(
+      child: Text(
+        "Your Informations",
+        style: GoogleFonts.poppins(
+          fontSize: 20,
+          color: Colors.black,
+          fontWeight: FontWeight.w400,
         ),
       ),
     );

--- a/lib/Pages/Settings.dart
+++ b/lib/Pages/Settings.dart
@@ -1,77 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:navbar_custom/Pages/Files.dart';
-import 'package:navbar_custom/Pages/Homepage.dart';
-import 'package:navbar_custom/Pages/Info.dart';
 
-class Settings extends StatelessWidget{
-  Settings({super.key});
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
 
   @override
-  Widget build(BuildContext context){
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 5,
-        backgroundColor: Colors.blueAccent,
-        centerTitle: true,
-        title: Text(
-            "Settings",
-            style: GoogleFonts.poppins(
-                fontSize: 15,
-                color: Colors.white,
-                fontWeight: FontWeight.w800)),
-      ),
-      body:  Center(
-        child: Text(
-          "My Settings",
-          style: GoogleFonts.poppins(
-              fontSize: 20,
-              color: Colors.black,
-              fontWeight: FontWeight.w400),
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        "My Settings",
+        style: GoogleFonts.poppins(
+          fontSize: 20,
+          color: Colors.black,
+          fontWeight: FontWeight.w400,
         ),
-      ),
-      bottomNavigationBar: Container(
-          margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-          decoration: BoxDecoration(
-              boxShadow: [
-                BoxShadow(
-                    color: Colors.black.withOpacity(0.5),
-                    blurRadius: 25,
-                    offset: const Offset(0, 20))
-              ]),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(25),
-            child: NavigationBar(
-                indicatorColor: Colors.blueAccent,
-                elevation: 0,
-                height: 70,
-                selectedIndex: 3,
-                onDestinationSelected: (indexPage){
-                  switch (indexPage){
-                    case 0:
-                      Navigator.push(context, MaterialPageRoute(builder: (context)=>Homepage()));
-                      break;
-
-                    case 1:
-                      Navigator.push(context, MaterialPageRoute(builder: (context)=> Files()));
-                      break;
-
-                    case 2:
-                      Navigator.push(context, MaterialPageRoute(builder: (context)=>Informations()));
-                      break;
-
-                    case 3:
-                    // This Page
-                      break;
-                  }
-                },
-                destinations: const [
-                  NavigationDestination(icon: Icon(Icons.home_filled), label:"Homepage" ),
-                  NavigationDestination(icon: Icon(Icons.book_sharp), label: "Files"),
-                  NavigationDestination(icon: Icon(Icons.info_sharp), label: "Informations"),
-                  NavigationDestination(icon: Icon(Icons.settings), label: "Settings"),
-                ]),
-          )
       ),
     );
   }

--- a/lib/Pages/customnav.dart
+++ b/lib/Pages/customnav.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'Files.dart';
+import 'Homepage.dart';
+import 'Info.dart';
+import 'Settings.dart';
+
+class CustomNavbar extends StatefulWidget {
+  const CustomNavbar({super.key});
+
+  @override
+  State<CustomNavbar> createState() => _CustomNavbarState();
+}
+
+class _CustomNavbarState extends State<CustomNavbar> {
+  int _selectedIndex = 0; // Index de la page actuelle
+
+  final List<Widget> _pages = [
+    const HomePage(),
+    const FilesPage(),
+    const InformationsPage(),
+    const SettingsPage(),
+  ];
+
+  final List<String> _pageTitles = [
+    "Homepage",
+    "Files",
+    "Informations",
+    "Settings",
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 5,
+        backgroundColor: Colors.blueAccent,
+        centerTitle: true,
+        title: Text(
+          _pageTitles[_selectedIndex],
+          style: GoogleFonts.poppins(
+            fontSize: 15,
+            color: Colors.white,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ),
+      body: _pages[_selectedIndex],
+      bottomNavigationBar: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        decoration: BoxDecoration(
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.5),
+              blurRadius: 25,
+              offset: const Offset(0, 20),
+            )
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(25),
+          child: NavigationBar(
+            indicatorColor: Colors.blueAccent,
+            elevation: 0,
+            height: 70,
+            selectedIndex: _selectedIndex,
+            onDestinationSelected: (index) {
+              setState(() {
+                _selectedIndex = index;
+              });
+            },
+            destinations: const [
+              NavigationDestination(icon: Icon(Icons.home_filled), label: "Homepage"),
+              NavigationDestination(icon: Icon(Icons.book_sharp), label: "Files"),
+              NavigationDestination(icon: Icon(Icons.info_sharp), label: "Informations"),
+              NavigationDestination(icon: Icon(Icons.settings), label: "Settings"),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:navbar_custom/Pages/Homepage.dart';
+import 'Pages/customnav.dart';
 
 void main() {
   runApp(const MyApp());
@@ -10,13 +10,9 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
+      home: CustomNavbar(),
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home:  Homepage(),
     );
   }
 }


### PR DESCRIPTION
This pull request refactors the navigation structure of the app to use a single custom navigation bar component, centralizing page switching logic and simplifying individual page widgets. The navigation bar and app bar are now managed by the new `CustomNavbar` widget, and each page (`HomePage`, `FilesPage`, `InformationsPage`, `SettingsPage`) is simplified to only display its main content.

Key changes:

**Navigation Refactor**

- Introduced a new `CustomNavbar` stateful widget in `customnav.dart` that manages navigation and app bar title for all main pages, replacing the duplicated navigation logic previously present in each page. (`lib/Pages/customnav.dart`)
- Updated the app entry point in `main.dart` to use `CustomNavbar` as the home widget, removing direct references to individual pages. (`lib/main.dart`) [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L2-R2) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L13-L19)

**Page Simplification and Renaming**

- Refactored `Homepage`, `Files`, `Informations`, and `Settings` widgets to `HomePage`, `FilesPage`, `InformationsPage`, and `SettingsPage` respectively. Each now only displays its core content and no longer contains navigation or app bar logic. [[1]](diffhunk://#diff-2fe78191b11214fb0f4ddd37abc8ffa0635403188b8eca23db821939b4043da2R1-L105) [[2]](diffhunk://#diff-3afc35aeed2f30abb5175062095efd9d7ca62a67fd27e7afa4e95ce1ac4619daL3-L105) [[3]](diffhunk://#diff-03b45079d30b0834cd3e25d6a12220f1aa57f0085be4e1aa28b2a70fce865fccR1-R10) [[4]](diffhunk://#diff-59c264116717c5124cacee53931e6b782f15f30909e1bc2dceb776b73c040bcbL3-L75)
- Removed all bottom navigation bar and app bar code from the individual page widgets, delegating this responsibility to `CustomNavbar`. [[1]](diffhunk://#diff-2fe78191b11214fb0f4ddd37abc8ffa0635403188b8eca23db821939b4043da2R1-L105) [[2]](diffhunk://#diff-3afc35aeed2f30abb5175062095efd9d7ca62a67fd27e7afa4e95ce1ac4619daL3-L105) [[3]](diffhunk://#diff-03b45079d30b0834cd3e25d6a12220f1aa57f0085be4e1aa28b2a70fce865fccL35-L105) [[4]](diffhunk://#diff-59c264116717c5124cacee53931e6b782f15f30909e1bc2dceb776b73c040bcbL3-L75)

**Code Cleanup**

- Removed unnecessary imports of other pages within each page file, since navigation is now managed centrally. [[1]](diffhunk://#diff-2fe78191b11214fb0f4ddd37abc8ffa0635403188b8eca23db821939b4043da2R1-L105) [[2]](diffhunk://#diff-3afc35aeed2f30abb5175062095efd9d7ca62a67fd27e7afa4e95ce1ac4619daL3-L105) [[3]](diffhunk://#diff-03b45079d30b0834cd3e25d6a12220f1aa57f0085be4e1aa28b2a70fce865fccR1-R10) [[4]](diffhunk://#diff-59c264116717c5124cacee53931e6b782f15f30909e1bc2dceb776b73c040bcbL3-L75)